### PR TITLE
Fix 404 in Streams link + other typo on Intro page 

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -52,7 +52,7 @@ Check out our [support guidelines](/docs/support) for the best way to obtain sup
 
 ### Learn Fundamental Concepts
 * [Data Types](/docs/data-types-intro) - Learn about supported data types such as lists, hashes, sets, sorted sets
-* KeyDB also supports more complex data types such as [Streams](/docs/streams), [publish/subscribe](/docs/pubsub), and [transactions](/docs/transactions)
+* KeyDB also supports more complex data types such as [Streams](/docs/streams-intro), [publish/subscribe](/docs/pubsub), and [transactions](/docs/transactions)
 * [Conventional Replication](/docs/replication) or [Active-Replication](/docs/active-rep)
 * [Cluster Mode](/docs/cluster-spec) - for creating a sharded data set
 * [Persistence](/docs/persistence) - Learn about methods for persisting data to disk

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -60,7 +60,7 @@ Check out our [support guidelines](/docs/support) for the best way to obtain sup
 
 ### Start Playing with KeyDB
 * [Download KeyDB](/docs/download) - See different download options for KeyDB
-* [Your Fist Command](/docs/first-test) - An intro to connecting to KeyDB
+* [Your First Command](/docs/first-test) - An intro to connecting to KeyDB
 * [Using keydb-cli](/docs/keydbcli) - Using the powerful KeyDB client interface
 * [Commands](/docs/commands) - A full list of commands you can use with KeyDB
 


### PR DESCRIPTION
### Context
On the intro page, there's a broken link in to the Streams page and a small typo

### Description of Change
Corrects the typo and the broken link - https://docs.keydb.dev/docs/streams-intro/

### Notes
Since all of the URLs are relative It will work when tested on docs.keydb.dev but not on GitHub